### PR TITLE
Fixed leading comment count increase

### DIFF
--- a/lib/src/pbxproj/list/list_pbx.dart
+++ b/lib/src/pbxproj/list/list_pbx.dart
@@ -39,11 +39,13 @@ class ListPbx extends NamedComponent {
     _children.insertAll(index, iterable);
   }
 
-  int indexOf(ElementOfListPbx element, [int start = 0]) => _children.indexOf(element, start);
+  int indexOf(ElementOfListPbx element, [int start = 0]) =>
+      _children.indexOf(element, start);
 
   bool any(bool Function(ElementOfListPbx e) test) => _children.any(test);
 
-  int indexWhere(bool Function(ElementOfListPbx e) test, [int start = 0]) => _children.indexWhere(test, start);
+  int indexWhere(bool Function(ElementOfListPbx e) test, [int start = 0]) =>
+      _children.indexWhere(test, start);
 
   ElementOfListPbx get first => _children.first;
 

--- a/lib/src/pbxproj/pbxproj_parse.dart
+++ b/lib/src/pbxproj/pbxproj_parse.dart
@@ -329,12 +329,12 @@ Pbxproj parsePbxproj(String content, String path, {bool debug = false}) {
       }
     }
 
-    var openingWasEncountered = false;
+    final startModelIndex = content.indexOf('{');
+    index = startModelIndex.clamp(0, content.length);
 
     while (index < content.length) {
       skipPattern(';');
       if (current().startsWith('{')) {
-        openingWasEncountered = true;
         printD('J FOUND {');
         skipPattern('{');
       } else
@@ -352,9 +352,7 @@ Pbxproj parsePbxproj(String content, String path, {bool debug = false}) {
       } else if (current().startsWith('//')) {
         printD('J FOUND comment //');
         final comment = parseCommentLine();
-        if (openingWasEncountered) {
-          addChild(comment);
-        }
+        addChild(comment);
       } else if (current().startsWith('/*')) {
         printD('J FOUND Comment /*');
         final comment = parseComment();

--- a/lib/src/pbxproj/pbxproj_parse.dart
+++ b/lib/src/pbxproj/pbxproj_parse.dart
@@ -329,9 +329,12 @@ Pbxproj parsePbxproj(String content, String path, {bool debug = false}) {
       }
     }
 
+    var openingWasEncountered = false;
+
     while (index < content.length) {
       skipPattern(';');
       if (current().startsWith('{')) {
+        openingWasEncountered = true;
         printD('J FOUND {');
         skipPattern('{');
       } else
@@ -348,7 +351,10 @@ Pbxproj parsePbxproj(String content, String path, {bool debug = false}) {
         addChild(parseMap());
       } else if (current().startsWith('//')) {
         printD('J FOUND comment //');
-        addChild(parseCommentLine());
+        final comment = parseCommentLine();
+        if (openingWasEncountered) {
+          addChild(comment);
+        }
       } else if (current().startsWith('/*')) {
         printD('J FOUND Comment /*');
         final comment = parseComment();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xcode_parser
 description: Reading and analyzing the contents of .pbxproj files. Modifying project settings and configurations. Saving changes to .pbxproj files.
-version: 1.2.1
+version: 1.3.1
 repository: https://github.com/EclipseAndrey/xcode_parser
 homepage: https://github.com/EclipseAndrey/xcode_parser
 

--- a/test/pbxproj_test.dart
+++ b/test/pbxproj_test.dart
@@ -41,8 +41,9 @@ void main() {
     });
 
     test('Open Pbxproj file from string', () {
-      final openedProject =
-          Pbxproj.parse('// !\$*UTF8*\$!\n{\n // !\$*UTF8*\$!\n}', path: tempFilePath);
+      final openedProject = Pbxproj.parse(
+          '// !\$*UTF8*\$!\n{\n // !\$*UTF8*\$!\n}',
+          path: tempFilePath);
       expect(openedProject.path, tempFilePath);
 
       expect(

--- a/test/pbxproj_test.dart
+++ b/test/pbxproj_test.dart
@@ -29,7 +29,7 @@ void main() {
 
     test('Open Pbxproj file', () async {
       final file = File(tempFilePath);
-      await file.writeAsString('// !\$*UTF8*\$!\n{}');
+      await file.writeAsString('// !\$*UTF8*\$!\n{\n // !\$*UTF8*\$!\n}');
       final openedProject = await Pbxproj.open(tempFilePath);
       expect(openedProject.path, tempFilePath);
 
@@ -42,7 +42,7 @@ void main() {
 
     test('Open Pbxproj file from string', () {
       final openedProject =
-          Pbxproj.parse('// !\$*UTF8*\$!\n{}', path: tempFilePath);
+          Pbxproj.parse('// !\$*UTF8*\$!\n{\n // !\$*UTF8*\$!\n}', path: tempFilePath);
       expect(openedProject.path, tempFilePath);
 
       expect(

--- a/test/xcode_parser_test.dart
+++ b/test/xcode_parser_test.dart
@@ -35,6 +35,31 @@ void main() {
       expect(pbxproj.childrenList, isEmpty);
     });
 
+    test('Open Pbxproj file with multiple comments', () async {
+      final inputContents = '''// !\$*UTF8*\$!
+{
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	// !\$*UTF8*\$!
+	archiveVersion = 1;
+	classes = {};
+	objectVersion = 54;
+}''';
+      final file = File(tempFilePath);
+      await file.create(recursive: true);
+      await file.writeAsString(inputContents);
+
+      final pbxproj = await Pbxproj.open(tempFilePath);
+      await pbxproj.save();
+
+      final outputContents = file.readAsStringSync();
+      expect(inputContents, outputContents);
+    });
+
     test('Open Pbxproj file with content', () async {
       final file = File(tempFilePath);
       await file.create(recursive: true);


### PR DESCRIPTION
Probably not the best solution, but it did the trick.
So basically I use this library in my build scripts in order to edit `iOS` projects on-fly.

They usually start with
```conf
// !$*UTF8*$!
{
	archiveVersion = 1;
	classes = {
	};
	objectVersion = 54;
```

The `// !$*UTF8*$!` in the first line will be parsed as a `CommentPbx` instance and after `save()` call the output will contain:

```
// !$*UTF8*$!
{
	// !$*UTF8*$!
	archiveVersion = 1;
	classes = {
	};
	objectVersion = 54;
```

The fix basically skips everything before the first `{`